### PR TITLE
Successful ajax call to NY Times API. Currently only searching by 'be…

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -12,22 +12,24 @@ $(function() {
     });
 
     function getRequest(searchTerm) {
-
-
         var url = "https://api.nytimes.com/svc/search/v2/articlesearch.json";
-        url += '?' + $.param({
-            'api-key': "3e086fa1430d466ba4a63a7818c323a1",
-            'begin_date': searchTerm,
-            'end_date': ""
-        });
         $.ajax({
             url: url,
-            method: 'GET',
-        }).done(function(result) {
-            console.log(result);
-        }).fail(function(err) {
-            throw err;
+            type:'GET',
+            dataType: "json",
+            data: {
+                'api-key': "3e086fa1430d466ba4a63a7818c323a1",
+                'begin_date': searchTerm
+            },
+            success: function(data) {
+                console.log(data);
+            }
         });
+        // }).done(function(result) {
+        //     console.log(result);
+        // }).fail(function(err) {
+        //     throw err;
+        // });
 
     }
 


### PR DESCRIPTION
…gin_date'.
